### PR TITLE
Reworded critical hit effects for gorgon and plague tower

### DIFF
--- a/_site/_units/gorgon.md
+++ b/_site/_units/gorgon.md
@@ -12,7 +12,7 @@ special_rules:
   - walker
 notes:
   |
-    May transport ten infantry units without _Jump Packs_ or _Mounted_. Critical Hit Effect: Immobilized and D6 units being transported are hit. Subsequent critical hits destroy the unit.
+    May transport ten infantry units without _Jump Packs_ or _Mounted_. Critical Hit Effect: Immobilized, and D6 transported units of the owner’s choice are hit. Subsequent critical hits destroy the unit.
 weapons:
   -
     id: twin-heavy-stubber

--- a/_site/_units/plague-tower.md
+++ b/_site/_units/plague-tower.md
@@ -13,7 +13,7 @@ special_rules:
   - transport
 notes:
   |
-    May transport sixteen Great Unclean Ones or infantry units without _Jump Packs_ or _Mounted_; Great Unclean Ones count as two units each. Critical Hit Effect: The unit takes a point of damage and D3 units of the player’s choice that are being transported are destroyed.
+    May transport sixteen Great Unclean Ones or infantry units without _Jump Packs_ or _Mounted_; Great Unclean Ones count as two units each. Critical Hit Effect: The unit takes a point of damage and D3 transported units of the Chaos player’s choice are destroyed.
 weapons:
   -
     id: plague-mortar


### PR DESCRIPTION
Clarified wording for critical hit effects that require allocating hits to transported units