### PR TITLE
URL epic-wargaming.de free for purchase

### DIFF
--- a/_site/tournament-pack/index.html
+++ b/_site/tournament-pack/index.html
@@ -53,7 +53,7 @@ show_heading_numbers: true
 
   <h4>Where can I find more Epic army lists?</h4>
 
-  <p>TacComm has tons of them, and many are included in the <abbr title="Net Epic Armageddon">NetEA</abbr> Army List Compendium found on the <abbr title="Net Epic Armageddon">NetEA</abbr> website (<a href="http://www.net-armageddon.org/">net-armageddon.org</a>). They are clearly labelled as <abbr title="Net Epic Armageddon">NetEA</abbr> Approved, Developmental and Experimental so you have an idea on how well play-tested each list is. In addition, be sure to check out Epic-UK (<a href="http://epic-uk.co.uk/">epic-uk.co.uk</a>), epic_fr (<a href="http://epic-fr.niceboard.com/">epic-fr.niceboard.com</a>) or Epic Wargaming (<a href="http://www.epic-wargaming.de/">epic-wargaming.de</a>) to see what the locals in your area are using.</p>
+  <p>TacComm has tons of them, and many are included in the <abbr title="Net Epic Armageddon">NetEA</abbr> Army List Compendium found on the <abbr title="Net Epic Armageddon">NetEA</abbr> website (<a href="http://www.net-armageddon.org/">net-armageddon.org</a>). They are clearly labelled as <abbr title="Net Epic Armageddon">NetEA</abbr> Approved, Developmental and Experimental so you have an idea on how well play-tested each list is. In addition, be sure to check out Epic-UK (<a href="http://epic-uk.co.uk/">epic-uk.co.uk</a>) or epic_fr (<a href="http://epic-fr.niceboard.com/">epic-fr.niceboard.com</a>) to see what the locals in your area are using.</p>
 
   <h4>Where can I buy Epic models?</h4>
 


### PR DESCRIPTION
The URL epic-wargaming.de is free for purchase. The hosted EPIC forum is gone. :/